### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Try the [hosted version](http://apollo-email.netlify.com).
 
 ## Getting Started
 
-After [downloading this example](https://github.com/graphcool-examples/react-apollo-auth0-example/archive/master.zip) please follow the steps detailed in [the online guide](https://www.graph.cool/docs/reference/simple-api/user-authentication-eixu9osueb#auth0-social-logins).
+After [downloading this example](https://github.com/graphcool-examples/react-apollo-auth0-example/archive/master.zip) please follow the steps detailed in [the online guide](https://www.graph.cool/docs/tutorials/react-apollo-auth0-pheiph4ooj).
 
 A short summary is given below.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Try the [hosted version](http://apollo-email.netlify.com).
 
 ## Getting Started
 
-After [downloading this example](https://github.com/graphcool-examples/react-apollo-auth0-example/archive/master.zip) please follow the steps detailed in [the online guide](https://graph.cool/docs/guides/react-apollo-auth0-lock).
+After [downloading this example](https://github.com/graphcool-examples/react-apollo-auth0-example/archive/master.zip) please follow the steps detailed in [the online guide](https://www.graph.cool/docs/reference/simple-api/user-authentication-eixu9osueb#auth0-social-logins).
 
 A short summary is given below.
 


### PR DESCRIPTION
This link was broken: [broken link](https://graph.cool/docs/guides/react-apollo-auth0-lock)
So suggesting it be replaced with this one (unless you have a different link): [new link](https://www.graph.cool/docs/reference/simple-api/user-authentication-eixu9osueb#auth0-social-logins)