### PR TITLE
update Link to be imported from react-router-dom

### DIFF
--- a/src/components/NewPostLink.js
+++ b/src/components/NewPostLink.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'react-router'
+import { Link } from 'react-router-dom'
 
 
 export default class NewPostLink extends React.Component {


### PR DESCRIPTION
Updated Link import to use 'react-router-dom' instead of 'react-router'... This was a very very sneaky bug to find. 